### PR TITLE
fix nTime conversion

### DIFF
--- a/lib/jobManager.js
+++ b/lib/jobManager.js
@@ -205,7 +205,13 @@ var JobManager = module.exports = function JobManager(options) {
 
         //console.log('processShare ck2')
 
-        var nTimeInt = parseInt(util.reverseBuffer(new Buffer(nTime, 'hex')), 16);
+        var nTimeInt = parseInt(util.reverseBuffer(new Buffer(nTime, 'hex')).toString('hex'), 16);
+
+	if (Number.isNaN(nTimeInt)) {
+	    // console.log('Invalid nTime: ', nTimeInt, nTime)
+	    return shareError([20, 'invalid ntime'])
+	}
+
         if (nTimeInt < job.rpcData.curtime || nTimeInt > submitTime + 7200) {
             console.log('ntime out of range');
             return shareError([20, 'ntime out of range']);


### PR DESCRIPTION
The first argument of parseInt should be string, not buffer.
Without this fix there is possible the case in which shares will
be rejected with `ntime out of range`.

Small example:
```
// string f7b40161 <Buffer f7 b4 01 61>
// 10 1627501815 1627501827
```
For `nTime = "f7b40161"` , `nTimeInt` will be equal `10`, which is totally incorrect.

More details available here:

https://github.com/DeckerSU/node-stratum-pool/commit/796410ecbdab9e7ccc055e55880104fbc8716d00